### PR TITLE
Fix master thread cant finish

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except ImportError:
 
 setup(
     name='threadloop',
-    version='0.2.1',
+    version='0.2.2',
     author='Grayson Koonce',
     author_email='breerly@gmail.com',
     description='Tornado IOLoop Backed Concurrent Futures',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except ImportError:
 
 setup(
     name='threadloop',
-    version='0.2.2',
+    version='0.3.0',
     author='Grayson Koonce',
     author_email='breerly@gmail.com',
     description='Tornado IOLoop Backed Concurrent Futures',

--- a/threadloop/glossary.py
+++ b/threadloop/glossary.py
@@ -1,5 +1,0 @@
-from __future__ import absolute_import
-
-# how long in ms to check in the child thread
-# if it should self destruct
-CHILD_THREAD_SELF_DESTRUCT_CHECK_INTERVAL = 100


### PR DESCRIPTION
By marking the ioloop thread as a daemon, the parent thread is able to exit naturally, killing the daemon.

An excerpt from [threading.Thread](https://docs.python.org/2/library/threading.html#thread-objects):

> A thread can be flagged as a “daemon thread”. The significance of this flag is that the entire Python program exits when only daemon threads are left.

Tested by hand that this works; if you have a  idea for a code test let me know :)