### PR TITLE
Use threading.Event instead of flag.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,11 @@
 Changelog
 =========
 
-0.3.4 (unreleased)
+0.4.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added ``Thread.is_ready()``.
+- Switched blocking mechanism to use a ``threading.Event``.
 
 
 0.3.3 (2015-07-17)

--- a/tests/threadloop/test_threadloop.py
+++ b/tests/threadloop/test_threadloop.py
@@ -222,8 +222,8 @@ def test_block_until_thread_is_ready():
 
     threadloop = ThreadLoop()
 
-    assert not threadloop._ready.is_set()
+    assert not threadloop.is_ready()
 
     threadloop.start()
 
-    assert threadloop._ready.is_set()
+    assert threadloop.is_ready()

--- a/tests/threadloop/test_threadloop.py
+++ b/tests/threadloop/test_threadloop.py
@@ -222,8 +222,8 @@ def test_block_until_thread_is_ready():
 
     threadloop = ThreadLoop()
 
-    assert not threadloop._is_running
+    assert not threadloop._ready.is_set()
 
     threadloop.start()
 
-    assert threadloop._is_running
+    assert threadloop._ready.is_set()

--- a/tests/threadloop/test_threadloop.py
+++ b/tests/threadloop/test_threadloop.py
@@ -91,7 +91,7 @@ def test_use_existing_ioloop():
     io_loop = ioloop.IOLoop.current()
     threadloop = ThreadLoop(io_loop)
 
-    assert threadloop.io_loop is io_loop
+    assert threadloop._io_loop is io_loop
 
     @gen.coroutine
     def coroutine():

--- a/tests/threadloop/test_threadloop.py
+++ b/tests/threadloop/test_threadloop.py
@@ -227,3 +227,11 @@ def test_block_until_thread_is_ready():
     threadloop.start()
 
     assert threadloop.is_ready()
+
+
+def test_is_not_ready_when_ready_hasnt_been_sent():
+
+    threadloop = ThreadLoop()
+    threadloop._thread = True  # fake the Thread being set
+
+    assert not threadloop.is_ready()

--- a/threadloop/threadloop.py
+++ b/threadloop/threadloop.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from concurrent.futures import Future
-from threading import Thread, current_thread, Event
+from threading import Event, Thread
 
 from tornado import ioloop
 
@@ -39,7 +39,6 @@ class ThreadLoop(object):
 
     """
     def __init__(self, io_loop=None):
-        self.main_thread = current_thread()
 
         self.thread = None
         self._ready = Event()

--- a/threadloop/threadloop.py
+++ b/threadloop/threadloop.py
@@ -44,9 +44,9 @@ class ThreadLoop(object):
         self._ready = Event()
 
         if io_loop is None:
-            self.io_loop = ioloop.IOLoop()
+            self._io_loop = ioloop.IOLoop()
         else:
-            self.io_loop = io_loop
+            self._io_loop = io_loop
 
     def __enter__(self):
         self.start()
@@ -72,8 +72,8 @@ class ThreadLoop(object):
         def mark_as_ready():
             self._ready.set()
 
-        self.io_loop.add_callback(mark_as_ready)
-        self.io_loop.start()
+        self._io_loop.add_callback(mark_as_ready)
+        self._io_loop.start()
 
     def is_ready(self):
         """Is thread & ioloop ready."""
@@ -88,7 +88,7 @@ class ThreadLoop(object):
 
     def stop(self):
         """Stop IOLoop & close daemonized thread."""
-        self.io_loop.stop()
+        self._io_loop.stop()
         self._thread.join()
 
     def submit(self, fn, *args, **kwargs):
@@ -123,7 +123,7 @@ class ThreadLoop(object):
             # python3 just needs the exception, exc_info works fine
             future.set_exception(exception)
 
-        self.io_loop.add_callback(
+        self._io_loop.add_callback(
             lambda: fn(*args, **kwargs).add_done_callback(on_done)
         )
 

--- a/threadloop/threadloop.py
+++ b/threadloop/threadloop.py
@@ -101,8 +101,8 @@ class ThreadLoop(object):
         """
         if not self.is_ready():
             raise ThreadNotStartedError(
-                "The thread has not been started yet, make sure start has "
-                "been called first like so: ThreadLoop().start()"
+                "The thread has not been started yet, "
+                "make sure you call start() first"
             )
 
         future = Future()

--- a/threadloop/threadloop.py
+++ b/threadloop/threadloop.py
@@ -76,6 +76,17 @@ class ThreadLoop(object):
         self.io_loop.add_callback(mark_as_running)
         self.io_loop.start()
 
+    def is_ready(self):
+        """Is thread & ioloop ready."""
+
+        if not self.thread:
+            return False
+
+        if not self._ready.is_set():
+            return False
+
+        return True
+
     def stop(self):
         """Stop IOLoop & close daemonized thread."""
         self.io_loop.stop()
@@ -89,8 +100,11 @@ class ThreadLoop(object):
         :param kwargs: Kwargs to pass to coroutine
         :returns concurrent.futures.Future: future result of coroutine
         """
-        if not self._ready.is_set():
-            raise ThreadNotStartedError()
+        if not self.is_ready():
+            raise ThreadNotStartedError(
+                "The thread has not been started yet, make sure start has "
+                "been called first like so: ThreadLoop().start()"
+            )
 
         future = Future()
 

--- a/threadloop/threadloop.py
+++ b/threadloop/threadloop.py
@@ -40,7 +40,7 @@ class ThreadLoop(object):
     """
     def __init__(self, io_loop=None):
 
-        self.thread = None
+        self._thread = None
         self._ready = Event()
 
         if io_loop is None:
@@ -57,14 +57,14 @@ class ThreadLoop(object):
 
     def start(self):
         """Start IOLoop in daemonized thread."""
-        assert self.thread is None, 'thread already started'
+        assert self._thread is None, 'thread already started'
 
         # configure thread
-        self.thread = Thread(target=self._start_io_loop)
-        self.thread.daemon = True
+        self._thread = Thread(target=self._start_io_loop)
+        self._thread.daemon = True
 
         # begin thread and block until ready
-        self.thread.start()
+        self._thread.start()
         self._ready.wait()
 
     def _start_io_loop(self):
@@ -78,7 +78,7 @@ class ThreadLoop(object):
     def is_ready(self):
         """Is thread & ioloop ready."""
 
-        if not self.thread:
+        if not self._thread:
             return False
 
         if not self._ready.is_set():
@@ -89,7 +89,7 @@ class ThreadLoop(object):
     def stop(self):
         """Stop IOLoop & close daemonized thread."""
         self.io_loop.stop()
-        self.thread.join()
+        self._thread.join()
 
     def submit(self, fn, *args, **kwargs):
         """Submit Tornado Coroutine to IOLoop in daemonized thread.

--- a/threadloop/threadloop.py
+++ b/threadloop/threadloop.py
@@ -42,9 +42,6 @@ class ThreadLoop(object):
         self.main_thread = current_thread()
 
         self.thread = None
-
-        # a ready event, is_set() default is False
-        # until set is called
         self._ready = Event()
 
         if io_loop is None:

--- a/threadloop/threadloop.py
+++ b/threadloop/threadloop.py
@@ -70,10 +70,10 @@ class ThreadLoop(object):
 
     def _start_io_loop(self):
 
-        def mark_as_running():
+        def mark_as_ready():
             self._ready.set()
 
-        self.io_loop.add_callback(mark_as_running)
+        self.io_loop.add_callback(mark_as_ready)
         self.io_loop.start()
 
     def is_ready(self):


### PR DESCRIPTION
Looks like the right synchronization mechanism for this use case is `threading.Event`.

From [this blog](http://effbot.org/zone/thread-synchronization.htm):

> An event is a simple synchronization object; the event represents an internal flag, and threads can wait for the flag to be set, or set or clear the flag themselves.

This is far better than a flag that we infinite loop on.