### PR TITLE
allow plain functions to be executed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 0.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Synchronous functions (i.e., those not returning futures) can be submitted to
+  the loop.
 
 
 0.4.0 (2015-07-19)

--- a/tests/threadloop/test_threadloop.py
+++ b/tests/threadloop/test_threadloop.py
@@ -87,6 +87,21 @@ def test_coroutine_exception_contains_exc_info(threadloop):
     assert False, "should have thrown exception"
 
 
+def test_plain_function(threadloop):
+
+    def not_a_coroutine():
+        return "Hello World"
+
+    future = threadloop.submit(not_a_coroutine)
+
+    assert (
+        isinstance(future, Future),
+        "expected a concurrent.futures.Future"
+    )
+
+    assert future.result() == "Hello World"
+
+
 def test_use_existing_ioloop():
     io_loop = ioloop.IOLoop.current()
     threadloop = ThreadLoop(io_loop)

--- a/tests/threadloop/test_threadloop.py
+++ b/tests/threadloop/test_threadloop.py
@@ -19,6 +19,10 @@ def threadloop():
         yield threadloop
 
 
+class TestException(Exception):
+    pass
+
+
 def test_coroutine_returns_future(threadloop):
 
     @gen.coroutine
@@ -50,9 +54,6 @@ def test_propogates_arguments(threadloop):
 
 def test_coroutine_exception_propagates(threadloop):
 
-    class TestException(Exception):
-        pass
-
     @gen.coroutine
     def coroutine():
         raise TestException()
@@ -63,9 +64,6 @@ def test_coroutine_exception_propagates(threadloop):
 
 
 def test_coroutine_exception_contains_exc_info(threadloop):
-
-    class TestException(Exception):
-        pass
 
     @gen.coroutine
     def coroutine():
@@ -100,6 +98,39 @@ def test_plain_function(threadloop):
     )
 
     assert future.result() == "Hello World"
+
+
+def test_plain_function_exception_propagates(threadloop):
+
+    def not_a_coroutine():
+        raise TestException()
+
+    future = threadloop.submit(not_a_coroutine)
+
+    with pytest.raises(TestException):
+        future = threadloop.submit(not_a_coroutine)
+        future.result()
+
+
+def test_plain_function_exception_contains_exc_info(threadloop):
+
+    def not_a_coroutine():
+        raise TestException('something went wrong')
+
+    try:
+        threadloop.submit(not_a_coroutine).result()
+    except Exception:
+        e, tb = sys.exc_info()[1:]
+
+        assert isinstance(e, TestException)
+        assert isinstance(tb, TracebackType)
+
+        tb_out = traceback.extract_tb(tb)
+        assert "raise TestException('something went wrong')" in str(tb_out)
+
+        return
+
+    assert False, "should have thrown exception"
 
 
 def test_use_existing_ioloop():

--- a/threadloop/threadloop.py
+++ b/threadloop/threadloop.py
@@ -4,6 +4,7 @@ from concurrent.futures import Future
 from threading import Event, Thread
 
 from tornado import ioloop
+from tornado import gen
 
 from .exceptions import ThreadNotStartedError
 
@@ -124,7 +125,9 @@ class ThreadLoop(object):
             future.set_exception(exception)
 
         self._io_loop.add_callback(
-            lambda: fn(*args, **kwargs).add_done_callback(on_done)
+            lambda: gen.maybe_future(
+                fn(*args, **kwargs)
+            ).add_done_callback(on_done)
         )
 
         return future

--- a/threadloop/threadloop.py
+++ b/threadloop/threadloop.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import sys
 from concurrent.futures import Future
 from threading import Event, Thread
 
@@ -124,10 +125,19 @@ class ThreadLoop(object):
             # python3 just needs the exception, exc_info works fine
             future.set_exception(exception)
 
-        self._io_loop.add_callback(
-            lambda: gen.maybe_future(
-                fn(*args, **kwargs)
-            ).add_done_callback(on_done)
-        )
+        def do_it():
+            try:
+                result = gen.maybe_future(fn(*args, **kwargs))
+            except Exception:
+                # The function we ran didn't return a future and instead raised
+                # an exception. Let's pretend that it returned this dummy
+                # future with our stack trace.
+                f = gen.Future()
+                f.set_exc_info(sys.exc_info())
+                on_done(f)
+            else:
+                result.add_done_callback(on_done)
+
+        self._io_loop.add_callback(do_it)
 
         return future


### PR DESCRIPTION
The use case here is if I want to send some blocking work to the ioloop (like listening on a socket).