### PR TITLE
ThreadLoop() should not change the current thread's IOLoop

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed a bug where instantiating ``ThreadLoop`` would change the ``IOLoop``
+  for the current thread.
 
 
 1.0.0 (2015-10-05)

--- a/threadloop/threadloop.py
+++ b/threadloop/threadloop.py
@@ -44,11 +44,7 @@ class ThreadLoop(object):
 
         self._thread = None
         self._ready = Event()
-
-        if io_loop is None:
-            self._io_loop = ioloop.IOLoop()
-        else:
-            self._io_loop = io_loop
+        self._io_loop = io_loop
 
     def __enter__(self):
         self.start()
@@ -74,6 +70,9 @@ class ThreadLoop(object):
 
         def mark_as_ready():
             self._ready.set()
+
+        if not self._io_loop:
+            self._io_loop = ioloop.IOLoop()
 
         self._io_loop.add_callback(mark_as_ready)
         self._io_loop.start()


### PR DESCRIPTION
Apparently, instantiating IOLoop changes the current thread's IOLoop to that IOLoop.

@blampe @breerly 