### PR TITLE
fix spurious assertions that were always true

### DIFF
--- a/tests/threadloop/test_threadloop.py
+++ b/tests/threadloop/test_threadloop.py
@@ -36,10 +36,7 @@ def test_coroutine_returns_future(threadloop):
 
     future = threadloop.submit(coroutine)
 
-    assert (
-        isinstance(future, Future),
-        "expected a concurrent.futures.Future"
-    )
+    assert isinstance(future, Future), "expected a concurrent.futures.Future"
 
     assert future.result() == "Hello World"
 
@@ -93,10 +90,7 @@ def test_plain_function(threadloop):
 
     future = threadloop.submit(not_a_coroutine)
 
-    assert (
-        isinstance(future, Future),
-        "expected a concurrent.futures.Future"
-    )
+    assert isinstance(future, Future), "expected a concurrent.futures.Future"
 
     assert future.result() == "Hello World"
 


### PR DESCRIPTION
The syntax:

    assert foo, "message"

Checks `foo` and then prints "message" if `foo` is false.

The syntax:

    assert (foo, "message")

Checks that the tuple `(foo, "message")` is True, which it always is,
and therefore doesn't actually test anything.