### PR TITLE
Fix concurrent.future errors not being propagated

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix ``concurrent.Future`` exceptions not being propagated.
 
 
 1.0.1 (2015-12-17)

--- a/tests/threadloop/test_threadloop.py
+++ b/tests/threadloop/test_threadloop.py
@@ -83,6 +83,16 @@ def test_coroutine_exception_contains_exc_info(threadloop):
     )
 
 
+def test_propagate_concurrent_future_exception(threadloop):
+    def func():
+        future = Future()
+        future.set_exception(AttributeError())
+        return future
+
+    with pytest.raises(AttributeError):
+        threadloop.submit(func).result()
+
+
 def test_plain_function(threadloop):
 
     def not_a_coroutine():


### PR DESCRIPTION
Noticed this when working on YARPC - when I called a non existent function on an object, my test suite froze and I didn't get a stack trace. This fixed it.


BEFORE:

```
Traceback (most recent call last):
  File "/Users/graysonkoonce/yarpc/yarpc-python/env/lib/python2.7/site-packages/concurrent/futures/_base.py", line 300, in _invoke_callbacks
    callback(self)
  File "/Users/graysonkoonce/Uber/threadloop/threadloop/threadloop.py", line 142, in on_done
    exception, traceback = f.exc_info()[1:]
AttributeError: 'Future' object has no attribute 'exc_info'
```

AFTER:

```
______ test_should_call_procedure[tchannel] ___
tests/yarpc/sync/encoding/test_json.py:71: in test_should_call_procedure
    resp = future.result()
env/lib/python2.7/site-packages/concurrent/futures/_base.py:405: in result
    return self.__get_result()
yarpc/_future.py:72: in new_f
    return f(*args, **kwargs)
yarpc/encoding/json.py:58: in rpc_call_done
    result = f.result()
env/lib/python2.7/site-packages/concurrent/futures/_base.py:398: in result
    return self.__get_result()
../../Uber/threadloop/threadloop/threadloop.py:117: in execute
    result = gen.maybe_future(fn(*args, **kwargs))
yarpc/rpc.py:66: in call
    return_future = outbound.call(request)
yarpc/transport/tchannel/outbound.py:44: in call
    headers = serializer.serialie_header(None)
E   AttributeError: 'JsonSerializer' object has no attribute 'serialie_header'
```